### PR TITLE
Splitting the package into two packages for Core and the main plugin.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Digbyswift.Umbraco.SeoEditor.Core
+# Digbyswift.Umbraco.SeoEditor
 
 Supporting library for the Digbyswift.Umbraco.SeoEditor package.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Digbyswift.Umbraco.SeoEditor
+# Digbyswift.Umbraco.SeoEditor.Core
 
-A property editor for metadata, largely inspired by the v7 SeoMetadata package.
+Supporting library for the Digbyswift.Umbraco.SeoEditor package.

--- a/src/Digbyswift.Umbraco.SeoEditor.Core/Digbyswift.Umbraco.SeoEditor.Core.csproj
+++ b/src/Digbyswift.Umbraco.SeoEditor.Core/Digbyswift.Umbraco.SeoEditor.Core.csproj
@@ -1,0 +1,46 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+	  <TargetFramework>net6.0</TargetFramework>
+	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	  <ContentTargetFolders>.</ContentTargetFolders>
+	  <ImplicitUsings>enable</ImplicitUsings>
+	  <RootNamespace>Digbyswift.Umbraco.SeoEditor.Core</RootNamespace>
+	  <Title>Digbyswift.Umbraco.SeoEditor.Core</Title>
+	  <Authors>Digbyswift Ltd</Authors>
+	  <Copyright>Copyright © Digbyswift Ltd</Copyright>
+	  <PackageProjectUrl>https://github.com/digbyswift/Digbyswift.Umbraco.SeoEditor</PackageProjectUrl>
+	  <RepositoryUrl>https://github.com/digbyswift/Digbyswift.Umbraco.SeoEditor</RepositoryUrl>
+	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
+	  <PackageTags>c# umbraco</PackageTags>
+	  <PackageVersion>10.0.4</PackageVersion>
+	  <AssemblyVersion>10.0.4</AssemblyVersion>
+	  <FileVersion>10.0.4</FileVersion>
+	  <PackageIcon>package-icon.png</PackageIcon>
+	  <PackageIconUrl>package-icon.png</PackageIconUrl>
+	  <Nullable>enable</Nullable>
+	  <PackageReleaseNotes>Supporting library for the Digbyswift.Umbraco.SeoEditor package.</PackageReleaseNotes>
+	  <Description>Supporting library for the Digbyswift.Umbraco.SeoEditor package.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE" Link="LICENSE">
+      <PackagePath></PackagePath>
+      <Pack>true</Pack>
+    </None>
+    <None Include="..\..\package-icon.png" Link="package-icon.png">
+      <PackagePath></PackagePath>
+      <Pack>true</Pack>
+    </None>
+    <None Include="..\..\README.md" Link="README.md">
+      <PackagePath></PackagePath>
+      <Pack>true</Pack>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+	  <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+	  <PackageReference Include="Umbraco.Cms.Core" Version="10.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Digbyswift.Umbraco.SeoEditor.Core/Digbyswift.Umbraco.SeoEditor.Core.csproj
+++ b/src/Digbyswift.Umbraco.SeoEditor.Core/Digbyswift.Umbraco.SeoEditor.Core.csproj
@@ -21,6 +21,7 @@
 	  <Nullable>enable</Nullable>
 	  <PackageReleaseNotes>Supporting library for the Digbyswift.Umbraco.SeoEditor package.</PackageReleaseNotes>
 	  <Description>Supporting library for the Digbyswift.Umbraco.SeoEditor package.</Description>
+	  <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Digbyswift.Umbraco.SeoEditor.Core/Digbyswift.Umbraco.SeoEditor.Core.csproj
+++ b/src/Digbyswift.Umbraco.SeoEditor.Core/Digbyswift.Umbraco.SeoEditor.Core.csproj
@@ -13,9 +13,9 @@
 	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <PackageTags>c# umbraco</PackageTags>
-	  <PackageVersion>10.0.4</PackageVersion>
-	  <AssemblyVersion>10.0.4</AssemblyVersion>
-	  <FileVersion>10.0.4</FileVersion>
+	  <PackageVersion>10.1.0</PackageVersion>
+	  <AssemblyVersion>10.1.0</AssemblyVersion>
+	  <FileVersion>10.1.0</FileVersion>
 	  <PackageIcon>package-icon.png</PackageIcon>
 	  <PackageIconUrl>package-icon.png</PackageIconUrl>
 	  <Nullable>enable</Nullable>

--- a/src/Digbyswift.Umbraco.SeoEditor.Core/SeoEditorModel.cs
+++ b/src/Digbyswift.Umbraco.SeoEditor.Core/SeoEditorModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Digbyswift.Umbraco.SeoEditor;
+﻿namespace Digbyswift.Umbraco.SeoEditor.Core;
 
 public class SeoEditorModel
 {

--- a/src/Digbyswift.Umbraco.SeoEditor.Core/SeoEditorPropertyConverter.cs
+++ b/src/Digbyswift.Umbraco.SeoEditor.Core/SeoEditorPropertyConverter.cs
@@ -17,9 +17,6 @@ public sealed class SeoEditorPropertyConverter : PropertyValueConverterBase
 
     public override object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
     {
-        if (inter == null)
-            return null;
-
         if (inter is string stringInter)
             return JsonConvert.DeserializeObject<SeoEditorModel>(stringInter);
 

--- a/src/Digbyswift.Umbraco.SeoEditor.Core/SeoEditorPropertyConverter.cs
+++ b/src/Digbyswift.Umbraco.SeoEditor.Core/SeoEditorPropertyConverter.cs
@@ -2,7 +2,7 @@
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
 
-namespace Digbyswift.Umbraco.SeoEditor;
+namespace Digbyswift.Umbraco.SeoEditor.Core;
 
 public sealed class SeoEditorPropertyConverter : PropertyValueConverterBase
 {

--- a/src/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor.sln
+++ b/src/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.4.33103.184
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Digbyswift.Umbraco.SeoEditor", "Digbyswift.Umbraco.SeoEditor\Digbyswift.Umbraco.SeoEditor.csproj", "{70657AF1-494B-42D0-B7BA-B8C1DE882ACA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Digbyswift.Umbraco.SeoEditor.Core", "..\Digbyswift.Umbraco.SeoEditor.Core\Digbyswift.Umbraco.SeoEditor.Core.csproj", "{89703EAC-2BFA-4CC0-BB37-5F830253D988}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{70657AF1-494B-42D0-B7BA-B8C1DE882ACA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70657AF1-494B-42D0-B7BA-B8C1DE882ACA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70657AF1-494B-42D0-B7BA-B8C1DE882ACA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89703EAC-2BFA-4CC0-BB37-5F830253D988}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89703EAC-2BFA-4CC0-BB37-5F830253D988}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89703EAC-2BFA-4CC0-BB37-5F830253D988}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89703EAC-2BFA-4CC0-BB37-5F830253D988}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor.csproj
+++ b/src/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor.csproj
@@ -20,6 +20,7 @@
         <PackageIconUrl>package-icon.png</PackageIconUrl>
         <Nullable>enable</Nullable>
         <Description>A property editor for metadata, largely inspired by the v7 SeoMetadata package.</Description>
+        <LangVersion>default</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="App_Plugins\Digbyswift.Umbraco.SeoEditor\**" ExcludeFromSingleFile="true" CopyToPublishDirectory="Always" />

--- a/src/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor.csproj
+++ b/src/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor.csproj
@@ -13,29 +13,29 @@
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>c# umbraco</PackageTags>
-        <PackageVersion>10.0.3</PackageVersion>
-        <AssemblyVersion>10.0.3</AssemblyVersion>
-        <FileVersion>10.0.3</FileVersion>
+        <PackageVersion>10.0.4</PackageVersion>
+        <AssemblyVersion>10.0.54</AssemblyVersion>
+        <FileVersion>10.0.4</FileVersion>
         <PackageIcon>package-icon.png</PackageIcon>
         <PackageIconUrl>package-icon.png</PackageIconUrl>
         <Nullable>enable</Nullable>
+        <Description>A property editor for metadata, largely inspired by the v7 SeoMetadata package.</Description>
     </PropertyGroup>
     <ItemGroup>
-        <Content Include="App_Plugins\Digbyswift.Umbraco.SeoEditor\**" ExcludeFromSingleFile="true" CopyToPublishDirectory="Always"/>
-        <None Include="buildTransitive\**" Pack="true" PackagePath="buildTransitive"/>
+        <Content Include="App_Plugins\Digbyswift.Umbraco.SeoEditor\**" ExcludeFromSingleFile="true" CopyToPublishDirectory="Always" />
+        <None Include="buildTransitive\**" Pack="true" PackagePath="buildTransitive" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="..\..\..\package-icon.png" Pack="true" PackagePath=""/>
+        <None Include="..\..\..\package-icon.png" Pack="true" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="..\..\..\LICENSE" Pack="true" PackagePath=""/>
+        <None Include="..\..\..\LICENSE" Pack="true" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="..\..\..\README.md" Pack="true" PackagePath=""/>
+        <None Include="..\..\..\README.md" Pack="true" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
-        <PackageReference Include="Umbraco.Cms.Core" Version="10.0.1"/>
+      <ProjectReference Include="..\..\Digbyswift.Umbraco.SeoEditor.Core\Digbyswift.Umbraco.SeoEditor.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor.csproj
+++ b/src/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor/Digbyswift.Umbraco.SeoEditor.csproj
@@ -13,9 +13,9 @@
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>c# umbraco</PackageTags>
-        <PackageVersion>10.0.4</PackageVersion>
-        <AssemblyVersion>10.0.54</AssemblyVersion>
-        <FileVersion>10.0.4</FileVersion>
+        <PackageVersion>10.1.0</PackageVersion>
+        <AssemblyVersion>10.1.0</AssemblyVersion>
+        <FileVersion>10.1.0</FileVersion>
         <PackageIcon>package-icon.png</PackageIcon>
         <PackageIconUrl>package-icon.png</PackageIconUrl>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
… Doing this enables the Core package to be installed in other projects without also installing the corresponding editor files for the plugin.